### PR TITLE
Ask for extra headers

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -181,8 +181,8 @@ const filter = {
     types: ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
 };
 browser.webRequest.onBeforeRequest.addListener(requestUpdated, filter, ['blocking', 'requestBody']);
-browser.webRequest.onBeforeSendHeaders.addListener(requestUpdated, filter, ['requestHeaders']);
-browser.webRequest.onSendHeaders.addListener(requestUpdated, filter, ['requestHeaders']);
+browser.webRequest.onBeforeSendHeaders.addListener(requestUpdated, filter, ['requestHeaders', 'extraHeaders']);
+browser.webRequest.onSendHeaders.addListener(requestUpdated, filter, ['requestHeaders', 'extraHeaders']);
 browser.webRequest.onHeadersReceived.addListener(headersReceived, filter, ['blocking', 'responseHeaders']);
 browser.webRequest.onResponseStarted.addListener(requestUpdated, filter, ['responseHeaders']);
 browser.webRequest.onCompleted.addListener(finishRequest, filter, ['responseHeaders']);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create load test scripts to run in Loadster.",
-  "version": "2.5",
+  "version": "2.6",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
This is required to obtain the 'Referer' header from newer versions of Chrome, which is important for making sense of recording events. It used to be in here but must have gotten lost in the recent changes to the extension.