### PR TITLE
Fix race condition

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -68,10 +68,10 @@ async function requestUpdated (info) {
 //
 // Updates a request and checks if it's being redirected.
 // 
-function headersReceived (info) {
-    requestUpdated(info);
+async function headersReceived (info) {
+    await requestUpdated(info)
 
-    if (info.statusCode == 301 || info.statusCode == 302) {
+    if (info.statusCode === 301 || info.statusCode === 302) {
         requestRedirected(info);
     }
 };
@@ -105,11 +105,11 @@ function requestRedirected (info) {
 //
 // Finishes a normal request, marking it completed.
 //
-function finishRequest (info) {
+async function finishRequest (info) {
+    await requestUpdated(info);
+
     info.completed = true;
     info.timeCompleted = new Date().getTime();
-
-    requestUpdated(info);
 };
 
 //
@@ -240,7 +240,7 @@ browser.tabs.onActivated.addListener(async function (activeInfo) {
             });
         } catch (err) {
             console.log(err.message); // Could not establish connection. Receiving end does not exist.
-            
+
             manifest.content_scripts.forEach(data => {
                 data.js.forEach(script => {
                     browser.tabs.executeScript(tabId, {file: script});

--- a/js/background.js
+++ b/js/background.js
@@ -107,9 +107,11 @@ function requestRedirected (info) {
 //
 async function finishRequest (info) {
     await requestUpdated(info);
-
-    info.completed = true;
-    info.timeCompleted = new Date().getTime();
+    
+    if (info.requestId && requests[info.requestId]) {
+        requests[info.requestId].completed = true;
+        requests[info.requestId].timeCompleted = new Date().getTime();
+    }
 };
 
 //
@@ -255,7 +257,7 @@ browser.tabs.onActivated.addListener(async function (activeInfo) {
 //
 setInterval(function () {
     var upload = {};
-
+    
     for (var requestId in requests) {
         if (requests.hasOwnProperty(requestId)) {
             if (requests[requestId].completed) {
@@ -265,7 +267,7 @@ setInterval(function () {
             }
         }
     }
-
+    
     if (Object.keys(upload).length && isEnabled()) {
         var xhr = new XMLHttpRequest();
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create load test scripts to run in Loadster.",
-  "version": "2.6",
+  "version": "2.7",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
Two functions, `finishRequest` and `headersReceived`, both delegated to `async requestUpdated`, but they weren't waiting on the promise to finish. This created a race condition where requests were being considered "completed" before all the headers had been copied over, and sent to the server without headers.

This change fixes those race conditions, but I'm still a bit concerned about the possibility of race conditions from the primary listeners finishing out of order. For example, is it possible that the handler for `onCompleted` might execute before the handler for `onResponseStarted` was done? I haven't been able to make that happen so far but it's something to keep in mind.