### PR TITLE
Remove unsupported options from webRequest callbacks

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -183,8 +183,8 @@ const filter = {
     types: ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
 };
 browser.webRequest.onBeforeRequest.addListener(requestUpdated, filter, ['blocking', 'requestBody']);
-browser.webRequest.onBeforeSendHeaders.addListener(requestUpdated, filter, ['requestHeaders', 'extraHeaders']);
-browser.webRequest.onSendHeaders.addListener(requestUpdated, filter, ['requestHeaders', 'extraHeaders']);
+browser.webRequest.onBeforeSendHeaders.addListener(requestUpdated, filter, ['requestHeaders']);
+browser.webRequest.onSendHeaders.addListener(requestUpdated, filter, ['requestHeaders']);
 browser.webRequest.onHeadersReceived.addListener(headersReceived, filter, ['blocking', 'responseHeaders']);
 browser.webRequest.onResponseStarted.addListener(requestUpdated, filter, ['responseHeaders']);
 browser.webRequest.onCompleted.addListener(finishRequest, filter, ['responseHeaders']);


### PR DESCRIPTION
@azhawkes you were right. It seems Firefox stricter its rules in webRequest callback syntax. 
Should we go at 3.0 now? Sorry, the x.x.x format is more understandable to me