### PR TITLE
v7: Record actions in sub-frames

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -185,9 +185,9 @@ function handleCreatedRootTab (tab, port) {
 
 function navigationCommitted (details) {
     const { tabId, ...data } = details;
-    const ingoredTransitions = []; // ['auto_subframe']
+    const ignoredTransitions = ['auto_subframe'];
 
-    if (!ingoredTransitions.includes(data.transitionType) && ports.some(p => p.tabIds.includes(tabId))) {
+    if (!ignoredTransitions.includes(data.transitionType) && ports.some(p => p.tabIds.includes(tabId))) {
         const action = 'navigate'
         browserEvents[generateId(action)] = { action, data, tabId };
     }
@@ -254,7 +254,7 @@ browser.runtime.onConnect.addListener(function (port) {
 browser.runtime.onMessage.addListener(function(msg, sender) {
     if (msg.type === USER_ACTION) {
         const {action, ...data} = msg.value
-        
+
         browserEvents[generateId(action)] = { 
             action, 
             data, 

--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,8 @@
         "js/blinker.js",
         "js/windowEventRecorder.js"
       ],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ],
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "6",
+  "version": "7",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
Clicks that happened in iframes weren't getting recorded, but navigations were. I've changed that around so that clicks and other events do get recorded (with a pseudo-selector like `iframe[name="right"]` preceding the real selector) and navigations don't (since when we play the script, the frame will get loaded by the browser anyway, and we don't want it treated as a top-level navigation).