### PR TITLE
Remove the unused activeTab permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "9",
+  "version": "10",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",
@@ -44,7 +44,6 @@
     }
   ],
   "permissions": [
-    "activeTab",
     "storage",
     "webRequest",
     "webRequestBlocking",


### PR DESCRIPTION
Google's review said we are requesting unused permissions, and by process of elimination I think it's the `activeTab` permission. As far as I can tell everything works without it.