### PR TITLE
fix(recorder): L-126

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -5,7 +5,7 @@ const IGNORED_PREFIXES = [
   'https://speedway.app'
 ];
 const manifest = browser.runtime.getManifest();
-
+const defaultRecordingOptions = {};
 let requests = {}; // Requests are stored here until they are uploaded
 let browserEvents = {};
 let ports = []; // Listeners from the Loadster website that want to receive recording events
@@ -144,7 +144,8 @@ function blinkTitle(tick, port) {
       value: tick
     }).catch(err => { });
     browser.tabs.sendMessage(id, {
-      type: RECORDING
+      type: RECORDING,
+      options: defaultRecordingOptions
     }).catch(err => { });
   });
 }
@@ -224,7 +225,9 @@ browser.runtime.onConnect.addListener(function (port) {
   let tick = 0;
 
   port.onMessage.addListener(async function (msg) {
-    if (msg.type === PING) {
+    if (msg.type === OPTIONS) {
+      Object.assign(defaultRecordingOptions, msg.value || {});
+    } else if (msg.type === PING) {
       blinkTitle(tick, port);
       port.postMessage({ type: PONG, enabled: isEnabled() });
       tick++;

--- a/js/constants.js
+++ b/js/constants.js
@@ -6,4 +6,5 @@ const BLINK_TITLE = 'loadster_blink_title',
   RECORDING = 'loadster_recording',
   RECORDING_EVENTS = 'RecordingEvents',
   RECORDING_STOP = 'RecordingStop',
-  USER_ACTION = 'loadster_browser_event';
+  USER_ACTION = 'loadster_browser_event',
+  OPTIONS = 'loadster_recording_options';

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "13",
+  "version": "14",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
Filtering the `_ngcontent-ynh-` and `data-v-` attributes with regex. I think it's better to do so on the extension level. Also it would be easier to add the additional fields to the extension popup