### PR TITLE
V20

### DIFF
--- a/js/blinker.js
+++ b/js/blinker.js
@@ -1,18 +1,24 @@
 (function () {
-  const iconA = String.fromCodePoint(0x25CF);
-  const iconB = String.fromCodePoint(0x25CB);
+  if (!window.loadster_recording_blinker) {
+    const iconA = String.fromCodePoint(0x25CF);
+    const iconB = String.fromCodePoint(0x25CB);
 
-  window.loadsterOriginalTitle = window.document.title;
+    window.loadsterOriginalTitle = window.document.title;
 
-  const BLINK_TITLE = 'loadster_blink_title';
+    const BLINK_TITLE = 'loadster_blink_title';
 
-  browser.runtime.onMessage.addListener((msg) => {
-    if (msg.type === BLINK_TITLE) {
-      if (msg.value !== null) {
-        window.document.title = `${++msg.value % 2 ? iconA : iconB} ${window.loadsterOriginalTitle}`;
-      } else {
-        window.document.title = window.loadsterOriginalTitle;
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === BLINK_TITLE) {
+        if (msg.value !== null) {
+          window.document.title = `${++msg.value % 2 ? iconA : iconB} ${window.loadsterOriginalTitle}`;
+        } else {
+          window.document.title = window.loadsterOriginalTitle;
+        }
       }
-    }
-  });
+    });
+
+    window.loadster_recording_blinker = true;
+  }
+
+  return true;
 }());

--- a/js/finder.js
+++ b/js/finder.js
@@ -1,418 +1,421 @@
 // https://github.com/antonmedv/finder (transpiled from ts)
 (function () {
-  let Limit;
+  if (!window.loadster_recording_finder) {
+    let Limit;
 
-  (function (Limit) {
-    Limit[Limit.All = 0] = 'All';
-    Limit[Limit.Two = 1] = 'Two';
-    Limit[Limit.One = 2] = 'One';
-  }(Limit || (Limit = {})));
-  let config,
-    rootDocument;
-  function finder(input, options) {
-    if (input.nodeType !== Node.ELEMENT_NODE) {
-      throw new Error('Can\'t generate CSS selector for non-element node type.');
-    }
+    (function (Limit) {
+      Limit[Limit.All = 0] = 'All';
+      Limit[Limit.Two = 1] = 'Two';
+      Limit[Limit.One = 2] = 'One';
+    }(Limit || (Limit = {})));
+    let config,
+      rootDocument;
 
-    if ('html' === input.tagName.toLowerCase()) {
-      return 'html';
-    }
-
-    const defaults = {
-      root: document.body,
-      idName: name => true,
-      className: name => true,
-      tagName: name => true,
-      attr: (name, value) => false,
-      seedMinLength: 1,
-      optimizedMinLength: 2,
-      threshold: 1000,
-      maxNumberOfTries: 10000
-    };
-    config = Object.assign(Object.assign({}, defaults), options);
-    rootDocument = findRootDocument(config.root, defaults);
-    let path = bottomUpSearch(input, Limit.All, () => bottomUpSearch(input, Limit.Two, () => bottomUpSearch(input, Limit.One)));
-
-    if (path) {
-      const optimized = sort(optimize(path, input));
-
-      if (optimized.length > 0) {
-        path = optimized[0];
+    function finder (input, options) {
+      if (input.nodeType !== Node.ELEMENT_NODE) {
+        throw new Error('Can\'t generate CSS selector for non-element node type.');
       }
 
-      return selector(path);
-    }
-    throw new Error('Selector was not found.');
-  }
+      if ('html' === input.tagName.toLowerCase()) {
+        return 'html';
+      }
 
-  function findRootDocument(rootNode, defaults) {
-    if (rootNode.nodeType === Node.DOCUMENT_NODE) {
+      const defaults = {
+        root: document.body,
+        idName: name => true,
+        className: name => true,
+        tagName: name => true,
+        attr: (name, value) => false,
+        seedMinLength: 1,
+        optimizedMinLength: 2,
+        threshold: 1000,
+        maxNumberOfTries: 10000
+      };
+      config = Object.assign(Object.assign({}, defaults), options);
+      rootDocument = findRootDocument(config.root, defaults);
+      let path = bottomUpSearch(input, Limit.All, () => bottomUpSearch(input, Limit.Two, () => bottomUpSearch(input, Limit.One)));
+
+      if (path) {
+        const optimized = sort(optimize(path, input));
+
+        if (optimized.length > 0) {
+          path = optimized[0];
+        }
+
+        return selector(path);
+      }
+      throw new Error('Selector was not found.');
+    }
+
+    function findRootDocument (rootNode, defaults) {
+      if (rootNode.nodeType === Node.DOCUMENT_NODE) {
+        return rootNode;
+      }
+
+      if (rootNode === defaults.root) {
+        return rootNode.ownerDocument;
+      }
+
       return rootNode;
     }
 
-    if (rootNode === defaults.root) {
-      return rootNode.ownerDocument;
-    }
-
-    return rootNode;
-  }
-
-  function bottomUpSearch(input, limit, fallback) {
-    let path = null,
-      stack = [],
-      current = input,
-      i = 0;
-
-    while (current && current !== config.root.parentElement) {
-      let level = maybe(id(current)) || maybe(...attr(current)) || maybe(...classNames(current)) || maybe(tagName(current)) || [any()];
-      const nth = index(current);
-
-      if (limit === Limit.All) {
-        if (nth) {
-          level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
-        }
-      } else if (limit === Limit.Two) {
-        level = level.slice(0, 1);
-
-        if (nth) {
-          level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
-        }
-      } else if (limit === Limit.One) {
-        const [node] = level = level.slice(0, 1);
-
-        if (nth && dispensableNth(node)) {
-          level = [nthChild(node, nth)];
-        }
-      }
-
-      for (const node of level) {
-        node.level = i;
-      }
-
-      stack.push(level);
-
-      if (stack.length >= config.seedMinLength) {
-        path = findUniquePath(stack, fallback);
-
-        if (path) {
-          break;
-        }
-      }
-
-      current = current.parentElement;
-      i++;
-    }
-
-    if (!path) {
-      path = findUniquePath(stack, fallback);
-    }
-
-    return path;
-  }
-
-  function findUniquePath(stack, fallback) {
-    const paths = sort(combinations(stack));
-
-    if (paths.length > config.threshold) {
-      return fallback ? fallback() : null;
-    }
-
-    for (const candidate of paths) {
-      if (unique(candidate)) {
-        return candidate;
-      }
-    }
-
-    return null;
-  }
-
-  function selector(path) {
-    let node = path[0],
-      query = node.name;
-
-    for (let i = 1; i < path.length; i++) {
-      const level = path[i].level || 0;
-
-      if (node.level === level - 1) {
-        query = `${path[i].name} > ${query}`;
-      } else {
-        query = `${path[i].name} ${query}`;
-      }
-
-      node = path[i];
-    }
-
-    return query;
-  }
-
-  function penalty(path) {
-    return path.map((node) => node.penalty).reduce((acc, i) => acc + i, 0);
-  }
-
-  function unique(path) {
-    switch (rootDocument.querySelectorAll(selector(path)).length) {
-      case 0:
-        throw new Error(`Can't select any node with this selector: ${selector(path)}`);
-
-      case 1:
-        return true;
-
-      default:
-        return false;
-    }
-  }
-
-  function id(input) {
-    const elementId = input.getAttribute('id');
-
-    if (elementId && config.idName(elementId)) {
-      return {
-        'name': `#${cssesc(elementId, {
-          isIdentifier: true
-        })}`,
-        'penalty': 0
-      };
-    }
-
-    return null;
-  }
-
-  function attr(input) {
-    const attrs = Array.from(input.attributes).filter((attr) => config.attr(attr.name, attr.value));
-    return attrs.map((attr) => ({
-      'name': `[${cssesc(attr.name, {
-        isIdentifier: true
-      })}="${cssesc(attr.value)}"]`,
-      'penalty': 0.5
-    }));
-  }
-
-  function classNames(input) {
-    const names = Array.from(input.classList).filter(config.className);
-    return names.map((name) => ({
-      'name': `.${cssesc(name, {
-        isIdentifier: true
-      })}`,
-      'penalty': 1
-    }));
-  }
-
-  function tagName(input) {
-    const name = input.tagName.toLowerCase();
-
-    if (config.tagName(name)) {
-      return {
-        name,
-        'penalty': 2
-      };
-    }
-
-    return null;
-  }
-
-  function any() {
-    return {
-      'name': '*',
-      'penalty': 3
-    };
-  }
-
-  function index(input) {
-    const parent = input.parentNode;
-
-    if (!parent) {
-      return null;
-    }
-
-    let child = parent.firstChild;
-
-    if (!child) {
-      return null;
-    }
-
-    let i = 0;
-
-    while (child) {
-      if (child.nodeType === Node.ELEMENT_NODE) {
-        i++;
-      }
-
-      if (child === input) {
-        break;
-      }
-
-      child = child.nextSibling;
-    }
-
-    return i;
-  }
-
-  function nthChild(node, i) {
-    return {
-      'name': `${node.name}:nth-child(${i})`,
-      'penalty': node.penalty + 1
-    };
-  }
-
-  function dispensableNth(node) {
-    return node.name !== 'html' && !node.name.startsWith('#');
-  }
-
-  function maybe(...level) {
-    const list = level.filter(notEmpty);
-
-    if (list.length > 0) {
-      return list;
-    }
-
-    return null;
-  }
-
-  function notEmpty(value) {
-    return value !== null && value !== undefined;
-  }
-
-  function* combinations(stack, path = []) {
-    if (stack.length > 0) {
-      for (const node of stack[0]) {
-        yield* combinations(stack.slice(1, stack.length), path.concat(node));
-      }
-    } else {
-      yield path;
-    }
-  }
-
-  function sort(paths) {
-    return Array.from(paths).sort((a, b) => penalty(a) - penalty(b));
-  }
-
-  function* optimize(path, input, scope = {
-    'counter': 0,
-    'visited': new Map()
-  }) {
-    if (path.length > 2 && path.length > config.optimizedMinLength) {
-      for (let i = 1; i < path.length - 1; i++) {
-        if (scope.counter > config.maxNumberOfTries) {
-          return; // Okay At least I tried!
-        }
-
-        scope.counter += 1;
-        const newPath = [...path];
-        newPath.splice(i, 1);
-        const newPathKey = selector(newPath);
-
-        if (scope.visited.has(newPathKey)) {
-          return;
-        }
-
-        if (unique(newPath) && same(newPath, input)) {
-          yield newPath;
-          scope.visited.set(newPathKey, true);
-          yield* optimize(newPath, input, scope);
-        }
-      }
-    }
-  }
-
-  function same(path, input) {
-    return rootDocument.querySelector(selector(path)) === input;
-  }
-
-  const regexAnySingleEscape = /[ -,\.\/:-@\[-\^`\{-~]/,
-    regexSingleEscape = /[ -,\.\/:-@\[\]\^`\{-~]/,
-    regexExcessiveSpaces = /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g,
-    defaultOptions = {
-      'escapeEverything': false,
-      'isIdentifier': false,
-      'quotes': 'single',
-      'wrap': false
-    };
-
-  function cssesc(string, opt = {}) {
-    const options = Object.assign({ ...defaultOptions }, opt);
-
-    if (options.quotes != 'single' && options.quotes != 'double') {
-      options.quotes = 'single';
-    }
-
-    const quote = options.quotes == 'double' ? '"' : '\'',
-      { isIdentifier } = options;
-    const firstChar = string.charAt(0);
-    let output = '',
-      counter = 0;
-    const { length } = string;
-
-    while (counter < length) {
-      const character = string.charAt(counter++);
-      let codePoint = character.charCodeAt(0),
-        value = void 0; // If it’s not a printable ASCII character…
-
-      if (codePoint < 0x20 || codePoint > 0x7E) {
-        if (codePoint >= 0xD800 && codePoint <= 0xDBFF && counter < length) {
-          // It’s a high surrogate, and there is a next character.
-          const extra = string.charCodeAt(counter++);
-
-          if ((extra & 0xFC00) == 0xDC00) {
-            // Next character is low surrogate
-            codePoint = ((codePoint & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000;
-          } else {
-            /*
-             * It’s an unmatched surrogate; only append this code unit, in case
-             * the next code unit is the high surrogate of a surrogate pair.
-             */
-            counter--;
+    function bottomUpSearch (input, limit, fallback) {
+      let path = null,
+        stack = [],
+        current = input,
+        i = 0;
+
+      while (current && current !== config.root.parentElement) {
+        let level = maybe(id(current)) || maybe(...attr(current)) || maybe(...classNames(current)) || maybe(tagName(current)) || [any()];
+        const nth = index(current);
+
+        if (limit === Limit.All) {
+          if (nth) {
+            level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
+          }
+        } else if (limit === Limit.Two) {
+          level = level.slice(0, 1);
+
+          if (nth) {
+            level = level.concat(level.filter(dispensableNth).map((node) => nthChild(node, nth)));
+          }
+        } else if (limit === Limit.One) {
+          const [node] = level = level.slice(0, 1);
+
+          if (nth && dispensableNth(node)) {
+            level = [nthChild(node, nth)];
           }
         }
 
-        value = `\\${codePoint.toString(16).toUpperCase()} `;
-      } else if (options.escapeEverything) {
-        if (regexAnySingleEscape.test(character)) {
+        for (const node of level) {
+          node.level = i;
+        }
+
+        stack.push(level);
+
+        if (stack.length >= config.seedMinLength) {
+          path = findUniquePath(stack, fallback);
+
+          if (path) {
+            break;
+          }
+        }
+
+        current = current.parentElement;
+        i++;
+      }
+
+      if (!path) {
+        path = findUniquePath(stack, fallback);
+      }
+
+      return path;
+    }
+
+    function findUniquePath (stack, fallback) {
+      const paths = sort(combinations(stack));
+
+      if (paths.length > config.threshold) {
+        return fallback ? fallback() : null;
+      }
+
+      for (const candidate of paths) {
+        if (unique(candidate)) {
+          return candidate;
+        }
+      }
+
+      return null;
+    }
+
+    function selector (path) {
+      let node = path[0],
+        query = node.name;
+
+      for (let i = 1; i < path.length; i++) {
+        const level = path[i].level || 0;
+
+        if (node.level === level - 1) {
+          query = `${path[i].name} > ${query}`;
+        } else {
+          query = `${path[i].name} ${query}`;
+        }
+
+        node = path[i];
+      }
+
+      return query;
+    }
+
+    function penalty (path) {
+      return path.map((node) => node.penalty).reduce((acc, i) => acc + i, 0);
+    }
+
+    function unique (path) {
+      switch (rootDocument.querySelectorAll(selector(path)).length) {
+        case 0:
+          throw new Error(`Can't select any node with this selector: ${selector(path)}`);
+
+        case 1:
+          return true;
+
+        default:
+          return false;
+      }
+    }
+
+    function id (input) {
+      const elementId = input.getAttribute('id');
+
+      if (elementId && config.idName(elementId)) {
+        return {
+          'name': `#${cssesc(elementId, {
+            isIdentifier: true
+          })}`,
+          'penalty': 0
+        };
+      }
+
+      return null;
+    }
+
+    function attr (input) {
+      const attrs = Array.from(input.attributes).filter((attr) => config.attr(attr.name, attr.value));
+      return attrs.map((attr) => ({
+        'name': `[${cssesc(attr.name, {
+          isIdentifier: true
+        })}="${cssesc(attr.value)}"]`,
+        'penalty': 0.5
+      }));
+    }
+
+    function classNames (input) {
+      const names = Array.from(input.classList).filter(config.className);
+      return names.map((name) => ({
+        'name': `.${cssesc(name, {
+          isIdentifier: true
+        })}`,
+        'penalty': 1
+      }));
+    }
+
+    function tagName (input) {
+      const name = input.tagName.toLowerCase();
+
+      if (config.tagName(name)) {
+        return {
+          name,
+          'penalty': 2
+        };
+      }
+
+      return null;
+    }
+
+    function any () {
+      return {
+        'name': '*',
+        'penalty': 3
+      };
+    }
+
+    function index (input) {
+      const parent = input.parentNode;
+
+      if (!parent) {
+        return null;
+      }
+
+      let child = parent.firstChild;
+
+      if (!child) {
+        return null;
+      }
+
+      let i = 0;
+
+      while (child) {
+        if (child.nodeType === Node.ELEMENT_NODE) {
+          i++;
+        }
+
+        if (child === input) {
+          break;
+        }
+
+        child = child.nextSibling;
+      }
+
+      return i;
+    }
+
+    function nthChild (node, i) {
+      return {
+        'name': `${node.name}:nth-child(${i})`,
+        'penalty': node.penalty + 1
+      };
+    }
+
+    function dispensableNth (node) {
+      return node.name !== 'html' && !node.name.startsWith('#');
+    }
+
+    function maybe (...level) {
+      const list = level.filter(notEmpty);
+
+      if (list.length > 0) {
+        return list;
+      }
+
+      return null;
+    }
+
+    function notEmpty (value) {
+      return value !== null && value !== undefined;
+    }
+
+    function* combinations (stack, path = []) {
+      if (stack.length > 0) {
+        for (const node of stack[0]) {
+          yield* combinations(stack.slice(1, stack.length), path.concat(node));
+        }
+      } else {
+        yield path;
+      }
+    }
+
+    function sort (paths) {
+      return Array.from(paths).sort((a, b) => penalty(a) - penalty(b));
+    }
+
+    function* optimize (path, input, scope = {
+      'counter': 0,
+      'visited': new Map()
+    }) {
+      if (path.length > 2 && path.length > config.optimizedMinLength) {
+        for (let i = 1; i < path.length - 1; i++) {
+          if (scope.counter > config.maxNumberOfTries) {
+            return; // Okay At least I tried!
+          }
+
+          scope.counter += 1;
+          const newPath = [...path];
+          newPath.splice(i, 1);
+          const newPathKey = selector(newPath);
+
+          if (scope.visited.has(newPathKey)) {
+            return;
+          }
+
+          if (unique(newPath) && same(newPath, input)) {
+            yield newPath;
+            scope.visited.set(newPathKey, true);
+            yield* optimize(newPath, input, scope);
+          }
+        }
+      }
+    }
+
+    function same (path, input) {
+      return rootDocument.querySelector(selector(path)) === input;
+    }
+
+    const regexAnySingleEscape = /[ -,\.\/:-@\[-\^`\{-~]/,
+      regexSingleEscape = /[ -,\.\/:-@\[\]\^`\{-~]/,
+      regexExcessiveSpaces = /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g,
+      defaultOptions = {
+        'escapeEverything': false,
+        'isIdentifier': false,
+        'quotes': 'single',
+        'wrap': false
+      };
+
+    function cssesc (string, opt = {}) {
+      const options = Object.assign({ ...defaultOptions }, opt);
+
+      if (options.quotes != 'single' && options.quotes != 'double') {
+        options.quotes = 'single';
+      }
+
+      const quote = options.quotes == 'double' ? '"' : '\'',
+        { isIdentifier } = options;
+      const firstChar = string.charAt(0);
+      let output = '',
+        counter = 0;
+      const { length } = string;
+
+      while (counter < length) {
+        const character = string.charAt(counter++);
+        let codePoint = character.charCodeAt(0),
+          value = void 0; // If it’s not a printable ASCII character…
+
+        if (codePoint < 0x20 || codePoint > 0x7E) {
+          if (codePoint >= 0xD800 && codePoint <= 0xDBFF && counter < length) {
+            // It’s a high surrogate, and there is a next character.
+            const extra = string.charCodeAt(counter++);
+
+            if ((extra & 0xFC00) == 0xDC00) {
+              // Next character is low surrogate
+              codePoint = ((codePoint & 0x3FF) << 10) + (extra & 0x3FF) + 0x10000;
+            } else {
+              /*
+               * It’s an unmatched surrogate; only append this code unit, in case
+               * the next code unit is the high surrogate of a surrogate pair.
+               */
+              counter--;
+            }
+          }
+
+          value = `\\${codePoint.toString(16).toUpperCase()} `;
+        } else if (options.escapeEverything) {
+          if (regexAnySingleEscape.test(character)) {
+            value = '\\' + character;
+          } else {
+            value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+          }
+        } else if (/[\t\n\f\r\x0B]/.test(character)) {
+          value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+        } else if (character == '\\' || !isIdentifier && (character == '"' && quote == character || character == '\'' && quote == character) || isIdentifier && regexSingleEscape.test(character)) {
           value = '\\' + character;
         } else {
-          value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+          value = character;
         }
-      } else if (/[\t\n\f\r\x0B]/.test(character)) {
-        value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
-      } else if (character == '\\' || !isIdentifier && (character == '"' && quote == character || character == '\'' && quote == character) || isIdentifier && regexSingleEscape.test(character)) {
-        value = '\\' + character;
-      } else {
-        value = character;
+
+        output += value;
       }
 
-      output += value;
-    }
+      if (isIdentifier) {
+        if ((/^-[-\d]/).test(output)) {
+          output = `\\-${output.slice(1)}`;
+        } else if ((/\d/).test(firstChar)) {
+          output = `\\3${firstChar} ${output.slice(1)}`;
+        }
+      } // Remove spaces after `\HEX` escapes that are not followed by a hex digit,
+      /*
+       * since they’re redundant. Note that this is only possible if the escape
+       * sequence isn’t preceded by an odd number of backslashes.
+       */
 
-    if (isIdentifier) {
-      if ((/^-[-\d]/).test(output)) {
-        output = `\\-${output.slice(1)}`;
-      } else if ((/\d/).test(firstChar)) {
-        output = `\\3${firstChar} ${output.slice(1)}`;
+
+      output = output.replace(regexExcessiveSpaces, function ($0, $1, $2) {
+        if ($1 && $1.length % 2) {
+          // It’s not safe to remove the space, so don’t.
+          return $0;
+        } // Strip the space.
+
+
+        return ($1 || '') + $2;
+      });
+
+      if (!isIdentifier && options.wrap) {
+        return quote + output + quote;
       }
-    } // Remove spaces after `\HEX` escapes that are not followed by a hex digit,
-    /*
-     * since they’re redundant. Note that this is only possible if the escape
-     * sequence isn’t preceded by an odd number of backslashes.
-     */
 
-
-    output = output.replace(regexExcessiveSpaces, function ($0, $1, $2) {
-      if ($1 && $1.length % 2) {
-        // It’s not safe to remove the space, so don’t.
-        return $0;
-      } // Strip the space.
-
-
-      return ($1 || '') + $2;
-    });
-
-    if (!isIdentifier && options.wrap) {
-      return quote + output + quote;
+      return output;
     }
 
-    return output;
+    window.loadster_recording_finder = finder;
   }
-
-  window.loadster_recording_finder = finder;
 
   return true;
 }());

--- a/js/windowEventRecorder.js
+++ b/js/windowEventRecorder.js
@@ -1,142 +1,145 @@
-
 (function (finder) {
-  const RECORDING = 'loadster_recording';
-  const RECORDING_STOP = 'RecordingStop';
-  const USER_ACTION = 'loadster_browser_event';
+  if (!window.loadster_event_recorder) {
+    const RECORDING = 'loadster_recording';
+    const RECORDING_STOP = 'RecordingStop';
+    const USER_ACTION = 'loadster_browser_event';
 
-  const windowEventsToRecord = {
-    'CLICK': 'click',
-    'DBLCLICK': 'dblclick',
-    'CHANGE': 'change',
-    'SELECT': 'select',
-    'SUBMIT': 'submit'
-  };
-  const options = {};
-  let enabled = false;
+    const windowEventsToRecord = {
+      'CLICK': 'click',
+      'DBLCLICK': 'dblclick',
+      'CHANGE': 'change',
+      'SELECT': 'select',
+      'SUBMIT': 'submit'
+    };
+    const options = {};
+    let enabled = false;
 
-  const sendMessage = (msg) => {
-    try {
-      browser.runtime.sendMessage({
-        'type': USER_ACTION,
-        'value': msg
-      });
-    } catch (err) {
-      // console.log(err);
-    }
-  };
+    const sendMessage = (msg) => {
+      try {
+        browser.runtime.sendMessage({
+          'type': USER_ACTION,
+          'value': msg
+        });
+      } catch (err) {
+        // console.log(err);
+      }
+    };
 
-  const recordEvent = (e) => {
-    if (!enabled) {
-      return;
-    }
-
-    const attrFilter = [
-      'class',
-      'id',
-      'style'
-    ];
-    const attrRegexFilter = options.attrRegExp ? new RegExp(options.attrRegExp) : null;
-    const idRegexFilter = options.idRegExp ? new RegExp(options.idRegExp) : null;
-
-    /*
-     * We explicitly catch any errors and swallow them, as none node-type events are also ingested.
-     * for these events we cannot generate selectors, which is OK
-     */
-    try {
-      let selector = finder(e.target, {
-        'idName': (name) => {
-          if (idRegexFilter && idRegexFilter.test(name)) return false;
-          return true;
-        },
-        'className': (name) => true, // !name.startsWith('is-') etc.
-        'tagName': (name) => true,
-        'attr': (name, value) => {
-          if (attrRegexFilter && attrRegexFilter.test(name)) return false;
-          if (attrFilter.includes(name)) return false;
-          return true;
-        },
-        'seedMinLength': 1, // Min 1
-        'optimizedMinLength': 2 // Min 2
-      });
-      const attrs = {};
-
-      for (let i = 0, x = e.target.attributes, n = x.length; i < n; i++) {
-        attrs[x[i].name] = x[i].value;
+    const recordEvent = (e) => {
+      if (!enabled) {
+        return;
       }
 
-      let frameSelector = '';
+      const attrFilter = [
+        'class',
+        'id',
+        'style'
+      ];
+      const attrRegexFilter = options.attrRegExp ? new RegExp(options.attrRegExp) : null;
+      const idRegexFilter = options.idRegExp ? new RegExp(options.idRegExp) : null;
 
-      if (window.parent !== window) {
-        let frame = window;
-        const frameTag = window.frameElement ? window.frameElement.tagName.toLowerCase() : 'iframe';
+      /*
+       * We explicitly catch any errors and swallow them, as none node-type events are also ingested.
+       * for these events we cannot generate selectors, which is OK
+       */
+      try {
+        let selector = finder(e.target, {
+          'idName': (name) => {
+            if (idRegexFilter && idRegexFilter.test(name)) return false;
+            return true;
+          },
+          'className': (name) => true, // !name.startsWith('is-') etc.
+          'tagName': (name) => true,
+          'attr': (name, value) => {
+            if (attrRegexFilter && attrRegexFilter.test(name)) return false;
+            if (attrFilter.includes(name)) return false;
+            return true;
+          },
+          'seedMinLength': 1, // Min 1
+          'optimizedMinLength': 2 // Min 2
+        });
+        const attrs = {};
 
-        if (frame.name) {
-          attrs.frameName = frame.name;
+        for (let i = 0, x = e.target.attributes, n = x.length; i < n; i++) {
+          attrs[x[i].name] = x[i].value;
+        }
 
-          frameSelector = `${frameTag}[name="${frame.name}"] ${frameSelector}`;
-        } else {
-          while (frame.parent !== frame) {
-            for (let i = 0; i < frame.parent.frames.length; i++) {
-              if (frame.parent.frames[i] === frame) {
-                attrs.frameIndex = i;
+        let frameSelector = '';
 
-                frameSelector = `${frameTag}[${i}] ${frameSelector}`.trim();
+        if (window.parent !== window) {
+          let frame = window;
+          const frameTag = window.frameElement ? window.frameElement.tagName.toLowerCase() : 'iframe';
+
+          if (frame.name) {
+            attrs.frameName = frame.name;
+
+            frameSelector = `${frameTag}[name="${frame.name}"] ${frameSelector}`;
+          } else {
+            while (frame.parent !== frame) {
+              for (let i = 0; i < frame.parent.frames.length; i++) {
+                if (frame.parent.frames[i] === frame) {
+                  attrs.frameIndex = i;
+
+                  frameSelector = `${frameTag}[${i}] ${frameSelector}`.trim();
+                }
               }
-            }
 
-            frame = frame.parent;
+              frame = frame.parent;
+            }
           }
         }
+
+        selector = `${frameSelector} ${selector}`.trim();
+
+        const textContent = e.target.textContent.trim();
+        let textSelector = '';
+        if (!e.target.children.length && textContent) {
+          textSelector = `${frameSelector} text=${textContent}`.trim();
+        }
+
+        const msg = {
+          'timestamp': Date.now(),
+          selector,
+          'value': e.target.value,
+          'tagName': e.target.tagName,
+          'action': e.type,
+          attrs,
+          'keyboard': {
+            'alt': e.altKey,
+            'shift': e.shiftKey,
+            'ctrl': e.ctrlKey,
+            'meta': e.metaKey
+          },
+          'textContent': e.target.textContent,
+          'textSelector': textSelector,
+          'href': e.target.href ? e.target.href : null
+        };
+
+        sendMessage(msg);
+      } catch (e) {
+        // console.log(e.message);
       }
+    };
 
-      selector = `${frameSelector} ${selector}`.trim();
+    const events = Object.values(windowEventsToRecord);
 
-      const textContent = e.target.textContent.trim();
-      let textSelector = '';
-      if (!e.target.children.length && textContent) {
-        textSelector = `${frameSelector} text=${textContent}`.trim();
+    events.forEach((type) => {
+      window.addEventListener(type, recordEvent, true);
+    });
+
+    browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+      if (msg.type === RECORDING && !enabled) {
+        enabled = true;
+        if (msg.options) {
+          Object.assign(options, msg.options);
+        }
+      } else if (msg.type === RECORDING_STOP) {
+        enabled = false;
       }
+    });
 
-      const msg = {
-        'timestamp': Date.now(),
-        selector,
-        'value': e.target.value,
-        'tagName': e.target.tagName,
-        'action': e.type,
-        attrs,
-        'keyboard': {
-          'alt': e.altKey,
-          'shift': e.shiftKey,
-          'ctrl': e.ctrlKey,
-          'meta': e.metaKey
-        },
-        'textContent': e.target.textContent,
-        'textSelector': textSelector,
-        'href': e.target.href ? e.target.href : null
-      };
-
-      sendMessage(msg);
-    } catch (e) {
-      // console.log(e.message);
-    }
-  };
-
-  const events = Object.values(windowEventsToRecord);
-
-  events.forEach((type) => {
-    window.addEventListener(type, recordEvent, true);
-  });
-
-  browser.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-    if (msg.type === RECORDING && !enabled) {
-      enabled = true;
-      if (msg.options) {
-        Object.assign(options, msg.options);
-      }
-    } else if (msg.type === RECORDING_STOP) {
-      enabled = false;
-    }
-  });
+    window.loadster_event_recorder = true;
+  }
 
   return true;
 }(window.loadster_recording_finder));

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "19",
+  "version": "20",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",

--- a/manifest-v3.json
+++ b/manifest-v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "19",
+  "version": "20",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
A customer reported that the extension wasn't able to record his site, and this led to me discovering a strange race condition where if the `navigationCommitted` event fired BEFORE the `onUpdatedTab` event, the content scripts failed to load into the parent frame. I think this only happened because of the way his site was structured with nested frames. Now, we'll just inject content scripts every time no matter what, since the content scripts themselves can safely be run again. This avoids this particular customer's race condition and also seems safer for race conditions in general than sending a message to check if they've already been run.

I also made a change to how we record "navigate" events. Previously they were created every time the outer frame switched to a different URL, but this was usually redundant, since the URL change was a result of a scripted click on a link or button or some other user action. Now, we'll record the initial navigation when the tab opens, and only record subsequent navigations if they are `typed` (into the URL bar).