### PR TITLE
v23. Accept custom ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+manifest.json
+.idea/

--- a/manifest-v2.json
+++ b/manifest-v2.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "22",
+  "version": "23",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",

--- a/manifest-v3.json
+++ b/manifest-v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Loadster Recorder",
   "description": "Create test scripts to run in Loadster and Speedway.",
-  "version": "22",
+  "version": "23",
   "icons": {
     "16": "images/icon-16x16.png",
     "32": "images/icon-32x32.png",


### PR DESCRIPTION
@azhawkes Now the browser recorder can accept as many filters as needed and use them automatically. See [Ember generated IDs mess up recordings](https://github.com/loadster/loadster-dashboard/pull/702)