### PR TITLE
Remove Storage Permission

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -28,7 +28,6 @@
     }
   ],
   "permissions": [
-    "storage",
     "scripting",
     "webRequest",
     "webNavigation"

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -25,7 +25,6 @@
     }
   ],
   "permissions": [
-    "storage",
     "webRequest",
     "webNavigation",
     "*://*/*"


### PR DESCRIPTION
We no longer use local storage or session storage, so I think it's safe to remove the `storage` permission. Also, Google's review flagged it as an unused permission after analyzing our code.