### PR TITLE
L-962 Record hover events with CSS significance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Loadster Recorder Extension",
   "type": "module",
-  "version": "26.0.0",
+  "version": "26.1.0",
   "description": "Create test scripts to run in Loadster.",
   "scripts": {
     "dev": "vite dev",

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -106,6 +106,11 @@ if (!window.loadsterRecorderScriptsLoaded) {
               } else {
                 // use the element's closest ancestor with a hover rule
               }
+            } else {
+              if (getElementListener(e.target, e.type)) {
+                element = e.target;
+                // js listener found, use the original element
+              }
             }
           }
         } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -1,6 +1,6 @@
 import { finder } from '@medv/finder';
 import { RECORDING_STATUS, USER_ACTION } from '../constants.js';
-import { overrideEventListeners, createMessage } from '../utils/windowUtils.js';
+import { overrideEventListeners, setupCSSHoverEventListener, createMessage } from '../utils/windowUtils.js';
 
 if (!window.loadsterRecorderScriptsLoaded) {
   window.loadsterRecorderScriptsLoaded = true;
@@ -11,6 +11,8 @@ if (!window.loadsterRecorderScriptsLoaded) {
     enabled = event.detail.enabled;
     updateFilters(event.detail.options);
   });
+
+  const { elementHasCSSHoverRule } = setupCSSHoverEventListener(false);
 
   overrideEventListeners();
 
@@ -64,7 +66,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
 
   const recordEvent = (e) => {
     if (!enabled) return;
-    if (!['auto', 'all'].includes(recordingOptions.recordHoverEvents) && ['mouseover', 'mouseenter'].includes(e.type)) return;
+    if (!['auto', 'all', 'css'].includes(recordingOptions.recordHoverEvents) && ['mouseover', 'mouseenter'].includes(e.type)) return;
 
     /*
      * We explicitly catch any errors and swallow them, as none node-type events are also ingested.
@@ -91,6 +93,8 @@ if (!window.loadsterRecorderScriptsLoaded) {
         if (recordingOptions.recordHoverEvents === 'all') {
           // use the element
         } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {
+          // use the element
+        } else if (recordingOptions.recordHoverEvents === 'css' && elementHasCSSHoverRule(e.target)) {
           // use the element
         } else {
           return;

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -17,7 +17,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
   overrideEventListeners();
 
   const recordingOptions = {
-    recordHoverEvents: 'none', // 'none' | 'auto' | 'all'
+    recordHoverEvents: 'none', // 'none' | 'auto' | 'css' | 'all'
     recordClickEvents: 'exact' // 'exact' | 'closest'
   };
   const filters = {
@@ -94,7 +94,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
           // use the element
         } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {
           // use the element
-        } else if (recordingOptions.recordHoverEvents === 'css' && elementHasCSSHoverRule(e.target)) {
+        } else if (recordingOptions.recordHoverEvents === 'css' && e.type === 'mouseenter' && elementHasCSSHoverRule(e.target)) {
           // use the element
         } else {
           return;
@@ -102,6 +102,8 @@ if (!window.loadsterRecorderScriptsLoaded) {
       }
 
       if (!element) return;
+
+      console.log(e.type);
 
       addTargetAttributes(element, attrs);
 

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -17,7 +17,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
   overrideEventListeners();
 
   const recordingOptions = {
-    recordHoverEvents: 'none', // 'none' | 'auto' | 'css' | 'all'
+    recordHoverEvents: 'none', // 'none' | 'auto' | 'all'
     recordClickEvents: 'exact' // 'exact' | 'closest'
   };
   const filters = {
@@ -66,7 +66,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
 
   const recordEvent = (e) => {
     if (!enabled) return;
-    if (!['auto', 'all', 'css'].includes(recordingOptions.recordHoverEvents) && ['mouseover', 'mouseenter'].includes(e.type)) return;
+    if (!['auto', 'all'].includes(recordingOptions.recordHoverEvents) && ['mouseover', 'mouseenter'].includes(e.type)) return;
 
     /*
      * We explicitly catch any errors and swallow them, as none node-type events are also ingested.
@@ -92,9 +92,9 @@ if (!window.loadsterRecorderScriptsLoaded) {
       } else if (['mouseenter', 'mouseover'].includes(e.type)) {
         if (recordingOptions.recordHoverEvents === 'all') {
           // use the element
-        } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {
+        } else if (recordingOptions.recordHoverEvents === 'auto' && e.type === 'mouseover' && elementHasCSSHoverRule(e.target)) {
           // use the element
-        } else if (recordingOptions.recordHoverEvents === 'css' && e.type === 'mouseenter' && elementHasCSSHoverRule(e.target)) {
+        } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {
           // use the element
         } else {
           return;
@@ -103,7 +103,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
 
       if (!element) return;
 
-      console.log(e.type);
+      // console.log(e.type);
 
       addTargetAttributes(element, attrs);
 

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -12,7 +12,7 @@ if (!window.loadsterRecorderScriptsLoaded) {
     updateFilters(event.detail.options);
   });
 
-  const { elementHasCSSHoverRule } = setupCSSHoverEventListener(false);
+  const { getElementWithCSSHoverRule, elementHasCSSHoverRule } = setupCSSHoverEventListener(false);
 
   overrideEventListeners();
 
@@ -92,8 +92,22 @@ if (!window.loadsterRecorderScriptsLoaded) {
       } else if (['mouseenter', 'mouseover'].includes(e.type)) {
         if (recordingOptions.recordHoverEvents === 'all') {
           // use the element
-        } else if (recordingOptions.recordHoverEvents === 'auto' && e.type === 'mouseover' && elementHasCSSHoverRule(e.target)) {
-          // use the element
+        } else if (recordingOptions.recordHoverEvents === 'auto' && e.type === 'mouseover') {
+          if (elementHasCSSHoverRule(e.target)) {
+            // use the exact element
+          } else {
+            element = getElementWithCSSHoverRule(e.target);
+
+            if (element) {
+              if (e.relatedTarget && element.contains(e.relatedTarget)) {
+                // console.log(`ignoring hover because it was already hovering a relative`, e.target, e.relatedTarget);
+
+                return;
+              } else {
+                // use the element's closest ancestor with a hover rule
+              }
+            }
+          }
         } else if (recordingOptions.recordHoverEvents === 'auto' && getElementListener(e.target, e.type)) {
           // use the element
         } else {

--- a/src/utils/windowUtils.js
+++ b/src/utils/windowUtils.js
@@ -59,6 +59,10 @@ export function createMessage(msg) {
   }
 }
 
+// Remove the :hover part of the selector to match the element itself
+function getBaseSelector(rule) {
+  return rule.selectorText.replace(':hover', '').trim();
+}
 
 // Get all CSSStyleRule[] from document that use :hover
 function getAllHoverRules() {
@@ -85,8 +89,7 @@ function getAllHoverRules() {
 // Get CSStyleRule in given collection
 function getElementCSSHoverRule(hoverRules, targetElement) {
   for (const rule of hoverRules) {
-    // Remove the :hover part of the selector to match the element itself
-    const baseSelector = rule.selectorText.replace(':hover', '').trim();
+    const baseSelector = getBaseSelector(rule);
 
     if (targetElement.matches(baseSelector)) {
       return rule;
@@ -105,6 +108,14 @@ export function setupCSSHoverEventListener(immediate = true) {
     });
   }
 
+  function getElementWithCSSHoverRule(targetElement) {
+    return hoverRules.map(hoverRule => {
+      const baseSelector = getBaseSelector(hoverRule);
+
+      return targetElement.closest(baseSelector);
+    }).find(el => !!el);
+  }
+
   function elementHasCSSHoverRule(targetElement) {
     const rule = getElementCSSHoverRule(hoverRules, targetElement);
 
@@ -114,6 +125,7 @@ export function setupCSSHoverEventListener(immediate = true) {
   }
 
   return {
+    getElementWithCSSHoverRule,
     elementHasCSSHoverRule
   };
 }

--- a/src/utils/windowUtils.js
+++ b/src/utils/windowUtils.js
@@ -74,6 +74,7 @@ function getAllHoverRules() {
         }
       }
     } catch (e) {
+      // console.log(e);
       // console.warn('Could not access some stylesheets due to cross-origin policy.');
     }
   }

--- a/src/utils/windowUtils.js
+++ b/src/utils/windowUtils.js
@@ -58,3 +58,61 @@ export function createMessage(msg) {
     return msg;
   }
 }
+
+
+// Get all CSSStyleRule[] from document that use :hover
+function getAllHoverRules() {
+  const hoverRules = [];
+
+  for (const stylesheet of document.styleSheets) {
+    try {
+      for (const rule of stylesheet.cssRules) {
+        if (rule instanceof CSSStyleRule) {
+          if (rule.selectorText.includes(':hover')) {
+            hoverRules.push(rule);
+          }
+        }
+      }
+    } catch (e) {
+      // console.warn('Could not access some stylesheets due to cross-origin policy.');
+    }
+  }
+
+  return hoverRules;
+}
+
+// Get CSStyleRule in given collection
+function getElementCSSHoverRule(hoverRules, targetElement) {
+  for (const rule of hoverRules) {
+    // Remove the :hover part of the selector to match the element itself
+    const baseSelector = rule.selectorText.replace(':hover', '').trim();
+
+    if (targetElement.matches(baseSelector)) {
+      return rule;
+    }
+  }
+}
+
+export function setupCSSHoverEventListener(immediate = true) {
+  const hoverRules = [];
+
+  if (immediate) {
+    hoverRules.push(...getAllHoverRules());
+  } else {
+    document.addEventListener('DOMContentLoaded', () => {
+      hoverRules.push(...getAllHoverRules());
+    });
+  }
+
+  function elementHasCSSHoverRule(targetElement) {
+    const rule = getElementCSSHoverRule(hoverRules, targetElement);
+
+    // rule && (targetElement.style.border = '1px solid red'); // Debug
+
+    return !!rule;
+  }
+
+  return {
+    elementHasCSSHoverRule
+  };
+}


### PR DESCRIPTION
This adds the ability to record hovered elements based on `CSSStyleRule` (:hover). This is an alternative way of recording hovered elements, compared to the somewhat "greedy" event-based recording (`mouseeneter` and `mouseover`).