### PR TITLE
Recorder records a click twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Loadster Recorder Extension",
   "type": "module",
-  "version": "26.3.0",
+  "version": "26.3.1",
   "description": "Create test scripts to run in Loadster.",
   "scripts": {
     "dev": "vite dev",

--- a/src/content/windowEventRecorder.js
+++ b/src/content/windowEventRecorder.js
@@ -358,6 +358,6 @@ if (!window.loadsterRecorderScriptsLoaded) {
   }
 
   events.forEach((type) => {
-    window.addEventListener(type, recordEvent, true);
+    window.addEventListener(type, recordEvent);
   });
 }


### PR DESCRIPTION
Stop using the `useCapture` parameter. It was causing unwanted duplicated recordings.